### PR TITLE
Potential fix for code scanning alert no. 90: Multiplication result converted to larger type

### DIFF
--- a/gladius/src/io/ImageStackExporter.cpp
+++ b/gladius/src/io/ImageStackExporter.cpp
@@ -276,7 +276,7 @@ namespace gladius::io
         std::vector<Lib3MF_uint8> inputData;
 
         inputData.resize(distmap.getData().size());
-        if (inputData.size() != m_columnCountWorld * m_rowCountWorld)
+        if (inputData.size() != static_cast<size_t>(m_columnCountWorld) * m_rowCountWorld)
         {
             throw std::runtime_error("Size of input data does not match the size of the image");
         }


### PR DESCRIPTION
Potential fix for [https://github.com/3MFConsortium/gladius/security/code-scanning/90](https://github.com/3MFConsortium/gladius/security/code-scanning/90)

To fix the issue, we need to ensure that the multiplication is conducted using the larger integer type (`size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands (`m_columnCountWorld` or `m_rowCountWorld`) to `size_t` before the multiplication. This will promote the entire operation to the larger type. The fix should be applied to the computation on line 279.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
